### PR TITLE
Fix code scanning alert no. 6: Multiplication result converted to larger type

### DIFF
--- a/src/cortex.c
+++ b/src/cortex.c
@@ -35,7 +35,7 @@ bhm_error_code_t i2d_init(bhm_input2d_t **input, bhm_cortex_size_t x0, bhm_corte
     (*input)->exc_value = exc_value;
 
     // Allocate values.
-    (*input)->values = (bhm_ticks_count_t *)malloc((x1 - x0) * (y1 - y0) * sizeof(bhm_ticks_count_t));
+    (*input)->values = (bhm_ticks_count_t *)malloc((size_t)(x1 - x0) * (y1 - y0) * sizeof(bhm_ticks_count_t));
     if ((*input)->values == NULL)
     {
         return BHM_ERROR_FAILED_ALLOC;
@@ -64,7 +64,7 @@ bhm_error_code_t o2d_init(bhm_output2d_t **output, bhm_cortex_size_t x0, bhm_cor
     (*output)->y1 = y1;
 
     // Allocate values.
-    (*output)->values = (bhm_ticks_count_t *)malloc((x1 - x0) * (y1 - y0) * sizeof(bhm_ticks_count_t));
+    (*output)->values = (bhm_ticks_count_t *)malloc((size_t)(x1 - x0) * (y1 - y0) * sizeof(bhm_ticks_count_t));
     if ((*output)->values == NULL)
     {
         printf("ERROR_ALLOCATING_VALUES\n");


### PR DESCRIPTION
Fixes [https://github.com/pmfs1/unknown/security/code-scanning/6](https://github.com/pmfs1/unknown/security/code-scanning/6)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the `size_t` type, which is large enough to hold the result without overflow.

Specifically, we will cast `(x1 - x0)` to `size_t` before the multiplication in the `malloc` call on line 38. We will apply the same fix to the similar multiplication on line 67.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
