### PR TITLE
Fix code scanning alert no. 1: Multiplication result converted to larger type

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -198,7 +198,7 @@ void c2d_from_file(bhm_cortex2d_t *cortex, char *file_name)
     fread(&(cortex->pulse_mapping), sizeof(bhm_pulse_mapping_t), 1, in_file);
 
     // Read all neurons.
-    cortex->neurons = (bhm_neuron_t *)malloc(cortex->width * cortex->height * sizeof(bhm_neuron_t));
+    cortex->neurons = (bhm_neuron_t *)malloc((size_t)cortex->width * cortex->height * sizeof(bhm_neuron_t));
     for (bhm_cortex_size_t y = 0; y < cortex->height; y++)
     {
         for (bhm_cortex_size_t x = 0; x < cortex->width; x++)


### PR DESCRIPTION
Fixes [https://github.com/pmfs1/unknown/security/code-scanning/1](https://github.com/pmfs1/unknown/security/code-scanning/1)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, preventing overflow.

Specifically, we will cast `cortex->width` to `size_t` before multiplying it by `cortex->height` on line 201. This change will ensure that the multiplication is performed using `size_t`, which is large enough to hold the result without overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
