### PR TITLE
Fix code scanning alert no. 2: Multiplication result converted to larger type

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -53,7 +53,7 @@ bhm_error_code_t pgm_read(pgm_content_t *pgm, const char *filename)
     ignoreComments(pgmfile);
 
     // Allocate memory to store data in the struct.
-    pgm->data = (uint8_t *)malloc(pgm->width * pgm->height * sizeof(uint8_t));
+    pgm->data = (uint8_t *)malloc((unsigned long)pgm->width * pgm->height * sizeof(uint8_t));
 
     // Store data in the struct.
     if (!strcmp(pgm->pgmType, "P2"))


### PR DESCRIPTION
Fixes [https://github.com/pmfs1/unknown/security/code-scanning/2](https://github.com/pmfs1/unknown/security/code-scanning/2)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `unsigned long` before performing the multiplication. This way, the multiplication will be done using `unsigned long`, which has a larger capacity and can hold the result without overflow.

Specifically, we will cast `pgm->width` to `unsigned long` before multiplying it by `pgm->height`. This change will be made in the file `src/utils.c` on line 56.
