### PR TITLE
Fix code scanning alert no. 3: Multiplication result converted to larger type

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -70,7 +70,7 @@ bhm_error_code_t pgm_read(pgm_content_t *pgm, const char *filename)
     else if (!strcmp(pgm->pgmType, "P5"))
     {
         // Raw data.
-        fread(pgm->data, sizeof(uint8_t), pgm->width * pgm->height, pgmfile);
+        fread(pgm->data, sizeof(uint8_t), (size_t)pgm->width * pgm->height, pgmfile);
     }
     else
     {


### PR DESCRIPTION
Fixes [https://github.com/pmfs1/unknown/security/code-scanning/3](https://github.com/pmfs1/unknown/security/code-scanning/3)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. Specifically, we should cast one of the operands to `size_t` before performing the multiplication. This will ensure that the multiplication is done using the `size_t` type, which is typically larger and can hold the result without overflow.

- Change the multiplication on line 73 to cast one of the operands to `size_t`.
- No additional methods or definitions are needed.
- No changes to imports are required.
