### PR TITLE
Fix code scanning alert no. 4: Multiplication result converted to larger type

### DIFF
--- a/src/cortex.c
+++ b/src/cortex.c
@@ -113,7 +113,7 @@ bhm_error_code_t c2d_init(bhm_cortex2d_t **cortex, bhm_cortex_size_t width, bhm_
     (*cortex)->pulse_mapping = BHM_PULSE_MAPPING_LINEAR;
 
     // Allocate neurons.
-    (*cortex)->neurons = (bhm_neuron_t *)malloc((*cortex)->width * (*cortex)->height * sizeof(bhm_neuron_t));
+    (*cortex)->neurons = (bhm_neuron_t *)malloc((size_t)(*cortex)->width * (*cortex)->height * sizeof(bhm_neuron_t));
     if ((*cortex)->neurons == NULL)
     {
         return BHM_ERROR_FAILED_ALLOC;


### PR DESCRIPTION
Fixes [https://github.com/pmfs1/unknown/security/code-scanning/4](https://github.com/pmfs1/unknown/security/code-scanning/4)

To fix the problem, we need to ensure that the multiplication is performed using a larger type to prevent overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, avoiding overflow.

Specifically, we will modify the line where the multiplication occurs in the `malloc` call to cast one of the operands to `size_t`.
