### PR TITLE
NOT ENOUGH MEMORY BEING ALLOCATED FOR THE ARRAY OF POINTER TYPE IN POPULATION.C:15

### DIFF
--- a/src/population.c
+++ b/src/population.c
@@ -12,7 +12,7 @@ int idf_compare(const void *a, const void *b)
 unk_error_code_t p2d_init(population2d_t **population, population_size_t size, population_size_t sel_pool_size, unk_chance_t mut_chance, cortex_fitness_t (*eval_function)(unk_cortex2d_t *cortex))
 {
     // Allocate the population.
-    (*population) = (population2d_t *)malloc(sizeof(unk_cortex2d_t));
+    (*population) = (population2d_t *)malloc(sizeof(population2d_t));
     if ((*population) == NULL)
     {
         return UNK_ERROR_FAILED_ALLOC;


### PR DESCRIPTION
_This pull request includes a crucial fix to the memory allocation in the `p2d_init` function within the `src/population.c` file. The most important change corrects the type used in the `malloc` call to ensure proper memory allocation for the `population2d_t` structure._

_**To ensure that the memory allocation on `src/population.c:15` correctly allocates enough memory for a `population2d_t` type. This can be achieved by using `sizeof(population2d_t)` instead of `sizeof(unk_cortex2d_t)`. This change ensures that the allocated memory is appropriate for the type of the pointer, preventing potential buffer overflows.**_
 - _Allocated memory (64 bytes) is not a multiple of the size of 'population2d_t' (48 bytes)._
   > _When you allocate an array from memory using malloc, calloc or realloc, you should ensure that you allocate enough memory to contain a multiple of the size of the required pointer type. Calls that are assigned to a non-void pointer variable, but do not allocate enough memory will cause a buffer overflow when a field accessed on the pointer points to memory that is beyond the allocated array. Buffer overflows can lead to anything from a segmentation fault to a security vulnerability._

###### _Memory allocation fix:_

* _[`src/population.c`](diffhunk://#diff-7b956a5b442cdc9b942f4456c29bab9ae0c4c84b2447bdcfae52f99ca8c6a713L15-R15): Corrected the type used in the `malloc` call from `unk_cortex2d_t` to `population2d_t` to ensure proper memory allocation for the population structure._